### PR TITLE
Shouhi resolve security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3449,6 +3449,11 @@
         "domutils": "^2.4.4"
       },
       "dependencies": {
+        "css-what": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/css-what/-/css-what-4.0.0.tgz",
+          "integrity": "sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A=="
+        },
         "domelementtype": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
@@ -4414,6 +4419,11 @@
         "nth-check": "^2.0.0"
       },
       "dependencies": {
+        "css-what": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/css-what/-/css-what-4.0.0.tgz",
+          "integrity": "sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A=="
+        },
         "nth-check": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
@@ -4441,9 +4451,9 @@
       }
     },
     "css-what": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-4.0.0.tgz",
-      "integrity": "sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+      "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg=="
     },
     "csscomb": {
       "version": "4.3.0",
@@ -6132,7 +6142,7 @@
       }
     },
     "fork-ts-checker-webpack-plugin-v5": {
-      "version": "npm:fork-ts-checker-webpack-plugin@5.2.1",
+      "version": "npm:fork-ts-checker-webpack-plugin-v5@5.2.1",
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
       "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
       "dev": true,
@@ -13105,7 +13115,7 @@
       }
     },
     "vue-loader-v16": {
-      "version": "npm:vue-loader@16.3.0",
+      "version": "npm:vue-loader-v16@16.3.0",
       "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.3.0.tgz",
       "integrity": "sha512-UDgni/tUVSdwHuQo+vuBmEgamWx88SuSlEb5fgdvHrlJSPB9qMBRF6W7bfPWSqDns425Gt1wxAUif+f+h/rWjg==",
       "dev": true,

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "axios": "^0.21.1",
     "compression-webpack-plugin": "^8.0.1",
     "core-js": "^3.4.4",
+    "css-what": "^5.0.1",
     "csscomb": "^4.3.0",
     "dayjs": "^1.8.20",
     "eslint": "^6.8.0",


### PR DESCRIPTION
## 変更の概要

* #4 

## なぜこの変更をするのか

* resolve security vulnerabilities of 130

## やったこと

* [x] upgrade axios to "0.21.1",
* [x] `npm audit`
▷ found 130 security vulnerabilities
▷ `npm audit fix`
▷ upgrade libraries to @latest


## 変更内容
<img width="1680" alt="スクリーンショット 2021-07-10 19 48 47" src="https://user-images.githubusercontent.com/63713624/125160444-d98b9380-e1b7-11eb-84d6-929382d13f8f.png">

## 課題

* can't upgrade css-white to 5.0.1 ver in package-lock.json.
*  [x] upgrade css-white to 5.0.1 ver in package.json